### PR TITLE
Add awk to container runtime

### DIFF
--- a/certificate-updater-ds.yaml
+++ b/certificate-updater-ds.yaml
@@ -41,6 +41,8 @@ spec:
           - sh
           - -c
           - |
+            apt-get update;
+            apt-get install original-awk;
             while true; do
               diff -x '.*' -r /mnt/user-cert-path/ /usr/local/share/ca-certificates
               if [ $? -ne 0 ];


### PR DESCRIPTION
Since the awk was removed from cr.yandex/yc/mk8s-openssl:stable, it must be installed into the container before the main cycle run.